### PR TITLE
修复ticker.Stop()导致资源泄露的问题

### DIFF
--- a/contrib/dlocker/redis/lock.go
+++ b/contrib/dlocker/redis/lock.go
@@ -164,6 +164,7 @@ func (rl *Lock) autoRenewalCallback(expire int) error {
 	}
 	rl.group.Go(func() error {
 		ticker := time.NewTicker(time.Second * time.Duration(expire))
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:

--- a/contrib/xcron/robfigcron/processor.go
+++ b/contrib/xcron/robfigcron/processor.go
@@ -245,6 +245,7 @@ func (s *processor) handle(req *Request) {
 
 func (s *processor) handleImmediatelyJob() {
 	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-s.closeChan:


### PR DESCRIPTION
1. dlocker 中. autorenewalcallback 的ticker使用
2. xcron job中 handleImmediatelyJob的ticker使用